### PR TITLE
rename .grassdata to grassdata 

### DIFF
--- a/system/admin/gislab-backupuser
+++ b/system/admin/gislab-backupuser
@@ -120,8 +120,8 @@ if ls $user_home_dir/.grass7 >/dev/null 2>&1; then
     tar -rf $home_backup_file $user_home_dir/.grass7
 fi
 
-if ls $user_home_dir/.grassdata >/dev/null 2>&1; then
-    tar -rf $home_backup_file $user_home_dir/.grassdata
+if ls $user_home_dir/grassdata >/dev/null 2>&1; then
+    tar -rf $home_backup_file $user_home_dir/grassdata
 fi
 
 bzip2 $home_backup_file

--- a/system/roles/account-users/tasks/main.yml
+++ b/system/roles/account-users/tasks/main.yml
@@ -194,7 +194,7 @@
     state: directory
   with_items:
     - "{{ root_dir }}/skel/.grass7"
-    - "{{ root_dir }}/skel/.grassdata"
+    - "{{ root_dir }}/skel/grassdata"
 
 - name: Install GRASS configuration
   template:
@@ -214,7 +214,7 @@
   with_items:
     - {
         src: static/grassdata/,
-        dest: "{{ root_dir }}/skel/.grassdata"
+        dest: "{{ root_dir }}/skel/grassdata"
       }
 
 

--- a/system/roles/account-users/templates/grass/rc.j2
+++ b/system/roles/account-users/templates/grass/rc.j2
@@ -1,4 +1,4 @@
 MAPSET: gislab
-GISDBASE: /mnt/home/{+ GISLAB_USER +}/.grassdata
+GISDBASE: /mnt/home/{+ GISLAB_USER +}/grassdata
 LOCATION_NAME: world
 GUI: wxpython


### PR DESCRIPTION
I suggest to rename `.grassdata` to `grassdata`. The main reason is that hidden directories are not visible in QGIS browser. The hidden GRASS data directory complicates usage of GRASS plugin. 
